### PR TITLE
Add a render_set method to Values

### DIFF
--- a/buildpg/components.py
+++ b/buildpg/components.py
@@ -82,7 +82,7 @@ class Component:
 
 
 class Values(Component):
-    __slots__ = 'values', 'names'
+    __slots__ = 'values', 'names', 'set'
 
     def __init__(self, *args, **kwargs):
         if (args and kwargs) or (not args and not kwargs):
@@ -104,6 +104,15 @@ class Values(Component):
         if not self.names:
             raise ComponentError(f'"names" are not available for nameless values')
         yield RawDangerous(', '.join(self.names))
+
+    def render_set(self):
+        if not self.names:
+            raise ComponentError(f'"set" are not available for nameless values')
+        yield RawDangerous('(')
+        yield RawDangerous(', '.join(self.names))
+        yield RawDangerous(') = (')
+        yield from yield_sep(self.values)
+        yield RawDangerous(')')
 
 
 class MultipleValues(Component):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -71,6 +71,12 @@ TESTS = [
         'expected_query': 'values: ($1, $2, $3), different: ($4, $5, $6)',
         'expected_params': [1, 2, 3, 1, 2, 3],
     },
+    {
+        'template': 'update table1 set :values__set from table2',
+        'ctx': lambda: dict(values=Values(column1='table2.col1', column2='table2.col2')),
+        'expected_query': 'update table1 set (column1, column2) = ($1, $2) from table2',
+        'expected_params': ['table2.col1', 'table2.col2'],
+    },
 ]
 
 


### PR DESCRIPTION
Not sure if that's what https://github.com/samuelcolvin/buildpg/issues/14 implies, but I found myself not finding any way to do something like:
```
UPDATE b
SET   (  column1,   column2,   column3)
    = (a.column1, a.column2, a.column3)
FROM   a
WHERE  b.id = 123    -- optional, to update only selected row
AND    a.id = b.id;
```
with `Values` as it is currently.

Hopefully I got it correctly, it's only been a few hours I'm playing with the lib !