### PR TITLE
Uprev to v0.23 of asyncpg

### DIFF
--- a/buildpg/asyncpg.py
+++ b/buildpg/asyncpg.py
@@ -3,6 +3,7 @@ from textwrap import indent
 
 from asyncpg import *  # noqa
 from asyncpg.pool import Pool
+from asyncpg.protocol import Record
 
 from .main import render
 
@@ -97,6 +98,7 @@ def create_pool_b(
     init=None,
     loop=None,
     connection_class=BuildPgConnection,
+    record_class=Record,
     **connect_kwargs,
 ):
     """
@@ -112,6 +114,7 @@ def create_pool_b(
     return BuildPgPool(
         dsn,
         connection_class=connection_class,
+        record_class=record_class,
         min_size=min_size,
         max_size=max_size,
         max_queries=max_queries,

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,5 @@
 black==18.9b0
-asyncpg==0.18.3
+asyncpg==0.23.0
 coverage==4.5.3
 docutils==0.14
 flake8==3.7.7


### PR DESCRIPTION
The new version of `asyncpg` requires some minor changes to `buildpg` to match `create_pool:

https://github.com/MagicStack/asyncpg/blob/075114c195e9eb4e81c8365d81540beefb46065c/asyncpg/pool.py#L799-L809

Seems you have no ci :upside_down_face: 

Test pass locally