### PR TITLE
Add is_distinct_from and is_not_distinct_from Operators

### DIFF
--- a/buildpg/logic.py
+++ b/buildpg/logic.py
@@ -49,6 +49,8 @@ class Operator(str, Enum):
     func = '_function_'
     nulls_first = ' NULLS FIRST'
     nulls_last = ' NULLS LAST'
+    is_distinct_from = ' is distinct from '
+    is_not_distinct_from = ' is not distinct from '
 
 
 @unique
@@ -82,6 +84,8 @@ PRECEDENCE = {
     Operator.matches: 35,
     Operator.is_: 35,
     Operator.is_not: 35,
+    Operator.is_distinct_from: 35,
+    Operator.is_not_distinct_from: 35,
     Operator.eq: 40,
     Operator.ne: 40,
     Operator.lt: 40,
@@ -227,6 +231,12 @@ class SqlBlock(Component):
 
     def nulls_last(self):
         return self.operate(Operator.nulls_last)
+
+    def is_distinct_from(self, other):
+        return self.operate(Operator.is_distinct_from, other)
+
+    def is_not_distinct_from(self, other):
+        return self.operate(Operator.is_not_distinct_from, other)
 
     def comma(self, other):
         return self.operate(Operator.comma, other)

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -137,6 +137,9 @@ def test_render(template, var, expected_query, expected_params):
         (lambda: V('foo').matches(V('bar')), 'foo @@ bar'),
         (lambda: V('foo').is_(V('bar')), 'foo is bar'),
         (lambda: V('foo').is_not(V('bar')), 'foo is not bar'),
+        (lambda: V('foo').is_distinct_from(V('bar')), 'foo is distinct from bar'),
+        (lambda: V('foo').is_not_distinct_from(V('bar')), 'foo is not distinct from bar'),
+
         (
             lambda: funcs.to_tsvector('fat cats ate rats').matches(funcs.to_tsquery('cat & rat')),
             'to_tsvector($1) @@ to_tsquery($2)',


### PR DESCRIPTION
Postgres ignores NULLs when doing comparisons . `... IS DISTINCT FROM ...` and `... IS NOT DISTINCT FROM ...` treats NULLs as comparable values.

[Postgres Docs](https://www.postgresql.org/docs/current/functions-comparison.html#FUNCTIONS-COMPARISON-PRED-TABLEl) 