### PR TITLE
Escape pipe chars in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,14 +105,14 @@ Both the pool and connections have `*_b` variants of all common query methods:
 | `**`                     | `^` |
 | `-`                      | `-` |
 | `~`                      | `not(...)` |
-| `sqrt`                   | `|/` |
+| `sqrt`                   | `\|/` |
 | `abs`                    | `@` |
 | `contains`               | `@>` |
 | `contained_by`           | `<@` |
 | `overlap`                | `&&` |
 | `like`                   | `LIKE` |
 | `ilike`                  | `ILIKE` |
-| `cat`                    | `||` |
+| `cat`                    | `\|\|` |
 | `in_`                    | `in` |
 | `from_`                  | `from` |
 | `at_time_zone`           | `AT TIME ZONE` |


### PR DESCRIPTION
Escape `|` (pipe character) so the README.md table can render the actual SQL syntax from python operator